### PR TITLE
Fix deactivate function to use quoted environment variable for checking non-zero length

### DIFF
--- a/script/activation.go
+++ b/script/activation.go
@@ -9,23 +9,23 @@ import (
 
 const scriptTemplate = `#!/bin/bash
 function deactivate() {
-	if [ -n ${GOVENV_OLD_PATH} ]; then
+	if [ -n "${GOVENV_OLD_PATH}" ]; then
 		PATH=${GOVENV_OLD_PATH}
 		export PATH
 		unset GOVENV_OLD_PATH
 	fi
 
-	if [ -n ${GOVENV_OLD_PS1} ]; then
+	if [ -n "${GOVENV_OLD_PS1}" ]; then
 		PS1=${GOVENV_OLD_PS1}
 		export PS1
 		unset GOVENV_OLD_PS1
 	fi
 
-	if [ -n ${GOROOT} ]; then
+	if [ -n "${GOROOT}" ]; then
 		unset GOROOT
 	fi
 
-	if [ -n ${GOPATH} ]; then
+	if [ -n "${GOPATH}" ]; then
 		unset GOPATH
 	fi
 


### PR DESCRIPTION
I guess `if [ -n $var]` expression always be true if we don't encapsulate the variable with double quote.

I faced an issue like this.
1. use activate to activate the project and govirtualenv
2. deactivate
3. then deactivate again
4. PATH environment variable is gone (no command is available)

I'm very happy if my modification makes some help for you!